### PR TITLE
Implemented Silver and Gold Amulets to Melanistic Calculator

### DIFF
--- a/pfq/melancalc/index.html
+++ b/pfq/melancalc/index.html
@@ -54,7 +54,7 @@ flex-flow: row wrap;
 <div id="flexcontainer"><div id="container"><h3>Melanistic Odds Calculator</h3>
 <form>
 <label>Shiny odds: 1/</label>
-<input type="text" id="baseshiny" value="200">
+<input type="text" id="baseshiny" value="160">
 <br>
 <label>Albino radar level: <span id="lvl"></span></label>
 <br>
@@ -76,6 +76,8 @@ flex-flow: row wrap;
 <label>Type Race Boost:</label>
 <input type="checkbox" id="typerace">
 <br>
+<label>Silver Amulet:</label>
+<input type="checkbox" id="silveramulet" checked>
 <label>PoTD boost:</label>
 <input type="checkbox" id="potd">
 </form>
@@ -91,8 +93,9 @@ flex-flow: row wrap;
 <ul>
 <li>Odds are referenced from <a href="https://pokefarm.com/forum/thread/341650/I-over-buffed-Melanistic-Pokemon">this announcement</a>.</li>
 <li>Since a Melanistic Pokemon occurs when a Pokemon is both Albino and Shiny, we can conclude that Melanistic odds are equal to Shiny odds * Albino odds.</li>
-<li>Shiny odds at a 40 chain (with Hypermode) are <b>1/200</b>. For non-Hypermode users, chains will max at 39, or <b>1/400</b>.</li>
-<li>Albino odds at level 7 (full charge) are <b>1/180</b>.</li>
+<li>Shiny odds at a 40 chain (with Hypermode) are <b>1/200</b>. For non-Hypermode users, chains will max at 39, or <b>1/400</b>.
+	<ul><li>If you have the Gold Amulet, these numbers change to <b>1/160</b> and <b>1/320</b> respectively.</li></ul></li>
+<li>Albino odds at level 7 (full charge) are <b>1/180</b>, <b>1/135</b> with the Silver Amulet.</li>
 <li>Long Chain bonus scaling can be found <a href="https://pokefarm.wiki/Melanistic_Hunting#Long_Chain_Bonus">here</a>, or directly on your Shiny Hunting page.</li>
 <li>Shiny Charm is a 2.5x modifier to Shiny odds.</li>
 <li>Z-Crystal is a 1.5x modifier to Albino odds.</li>

--- a/pfq/melancalc/main.js
+++ b/pfq/melancalc/main.js
@@ -47,7 +47,7 @@ function calculateOdds(baseShiny,albIndex,sei,longChain,shinyCharm,uberCharm,z,t
 	and then your Sei-boosted Shiny chances are 1/(sqrt(X/P)*P) - 
 	which now that I'm looking at it is really just 1/(sqrt(X) * sqrt(50-S))
 	*/
-	var baseAlbino = 6145.2;
+	var baseAlbino = 4608;
 	const albBoost = [1,2,4,8,12.8,22.76,34.14];
 	console.log("Albino odds at level " + albIndex + " (before Z): 1/" + baseAlbino/albBoost[albIndex-1]);
 	baseAlbino /= albBoost[albIndex-1]; //applies boost from alb radar level

--- a/pfq/melancalc/main.js
+++ b/pfq/melancalc/main.js
@@ -8,6 +8,7 @@ function main() {
 		document.getElementById('ubercharm').addEventListener('input', updateValues);
 		document.getElementById('z').addEventListener('input', updateValues);
 		document.getElementById('typerace').addEventListener('input', updateValues);
+		document.getElementById('silveramulet').addEventListener('input', updateValues);
 		document.getElementById('potd').addEventListener('input', updateValues);
 		document.getElementById('eggshatched').addEventListener('input', updateValues);
 		
@@ -36,21 +37,23 @@ function updateValues() {
 	var uberCharm = document.getElementById("ubercharm").checked;
 	var z = document.getElementById("z").checked;	
 	var typerace = document.getElementById("typerace").checked;
+	var silverAmulet = document.getElementById("silveramulet").checked;
 	var potd = document.getElementById("potd").checked;
 	longChain = 1 + longChain/100;
-	calculateOdds(baseShiny,albIndex,sei,longChain,shinyCharm,uberCharm,z,typerace,potd,eggsHatched);
+	calculateOdds(baseShiny,albIndex,sei,longChain,shinyCharm,uberCharm,z,typerace,silverAmulet,potd,eggsHatched);
 }
 
-function calculateOdds(baseShiny,albIndex,sei,longChain,shinyCharm,uberCharm,z,typerace,potd,eggsHatched) {
+function calculateOdds(baseShiny,albIndex,sei,longChain,shinyCharm,uberCharm,z,typerace,silveramulet,potd,eggsHatched) {
 	/*
 	If your Shiny chances are 1/X, and Sei power is S, then first convert Sei power into a modifier P = 50-S 
 	and then your Sei-boosted Shiny chances are 1/(sqrt(X/P)*P) - 
 	which now that I'm looking at it is really just 1/(sqrt(X) * sqrt(50-S))
 	*/
-	var baseAlbino = 4608;
+	var baseAlbino = 6144;
 	const albBoost = [1,2,4,8,12.8,22.76,34.14];
 	console.log("Albino odds at level " + albIndex + " (before Z): 1/" + baseAlbino/albBoost[albIndex-1]);
 	baseAlbino /= albBoost[albIndex-1]; //applies boost from alb radar level
+	if(silveramulet) baseAlbino/=4/3;
 	
 	
 	if(shinyCharm) baseShiny/=2.5; //2.5x shiny odds


### PR DESCRIPTION
Specific changes:
- Default Shiny Odds now 1/160 instead of 1/200
- New checkbox for Silver Amulet, checked by default (grants 4/3 albino multiplier)
- In the info box, added probabilities with Silver/Gold Amulet owned